### PR TITLE
Add utils::stack to prevent raster namespace error

### DIFF
--- a/R/get_clusters_from_data.R
+++ b/R/get_clusters_from_data.R
@@ -40,7 +40,7 @@ find_temporally_connected_points<-function(vec, eps_t){
 
   #collapse the sparse simmilarity list into a data.table
   names(sparse_sim) <- 1:length(vec)
-  sparse_sim <- stack(sparse_sim)
+  sparse_sim <- utils::stack(sparse_sim)
   data.table::setDT(sparse_sim)
 
   #return just the columns we need


### PR DESCRIPTION
Hi! I was looking for an existing ST-DBSCAN package on Github and yours came up. I am using your package for trajectory analysis and point analysis within these trajectories.  I am using raster and the following error came up: "unable to find an inherited method for function ‘raster’ for signature ‘"integer"". Maybe it would be better to use utils::stack to prevent this error for others using raster at the same time?